### PR TITLE
Bump base UBI version from 8.1 to 8.2, also with the CentOS repo path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN cd /build/src && \
 #-----------------------
 # Stage: Runtime
 #-----------------------
-FROM registry.access.redhat.com/ubi8/ubi:8.1-406 AS runtime
+FROM registry.access.redhat.com/ubi8/ubi:8.2-299 AS runtime
 
 # environment variables
 ARG interval=30

--- a/Dockerfile.ubi.amd64
+++ b/Dockerfile.ubi.amd64
@@ -20,7 +20,7 @@
 #-----------------------
 # Stage: base
 #-----------------------
-FROM registry.access.redhat.com/ubi8/ubi:8.1-406 AS base
+FROM registry.access.redhat.com/ubi8/ubi:8.2-299 AS base
 
 # Install Packages
 COPY ./scripts/installUBIDependency.sh /

--- a/scripts/installUBIDependency.sh
+++ b/scripts/installUBIDependency.sh
@@ -29,7 +29,7 @@ MODE=${1:-base}
 echo "Install Dependency under mode: ${MODE}"
 if [ "${MODE}" == "base" ] ; then
      # Run package installation for base images
-     dnf install -y --disableplugin=subscription-manager http://mirror.centos.org/centos/8/BaseOS/x86_64/os/Packages/centos-gpg-keys-8.1-1.1911.0.8.el8.noarch.rpm http://mirror.centos.org/centos/8/BaseOS/x86_64/os/Packages/centos-repos-8.1-1.1911.0.8.el8.x86_64.rpm
+     dnf install -y --disableplugin=subscription-manager http://mirror.centos.org/centos/8/BaseOS/x86_64/os/Packages/centos-gpg-keys-8.2-2.2004.0.1.el8.noarch.rpm http://mirror.centos.org/centos/8/BaseOS/x86_64/os/Packages/centos-repos-8.2-2.2004.0.1.el8.x86_64.rpm
      dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
      dnf -y install --enablerepo=PowerTools --disablerepo=ubi-8-codeready-builder  --disablerepo=ubi-8-appstream --disablerepo=ubi-8-baseos --disableplugin=subscription-manager \
         gcc \


### PR DESCRIPTION
This is to upgrade the base image and repo version from 8.1 to 8.2, then we should also fix the broken build.