### PR TITLE
Container: change package repository to RHEL 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG UBI_TAG=0.26.7
+ARG SYSDIG_VER=0.26.7
+ARG UBI_VER=8.2.299
 
 #-----------------------
 # Stage: builder
 #-----------------------
-FROM sysflowtelemetry/ubi:mods-${UBI_TAG} AS builder
+FROM sysflowtelemetry/ubi:mods-${SYSDIG_VER}-${UBI_VER} AS builder
 
 # environment and build args
 ARG BUILD_NUMBER=0
@@ -52,7 +53,7 @@ RUN cd /build/src && \
 #-----------------------
 # Stage: Runtime
 #-----------------------
-FROM sysflowtelemetry/ubi:base-${UBI_TAG} AS runtime
+FROM sysflowtelemetry/ubi:base-${SYSDIG_VER}-${UBI_VER} AS runtime
 
 # environment variables
 ARG interval=30

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN cd /build/src && \
 #-----------------------
 # Stage: Runtime
 #-----------------------
-FROM registry.access.redhat.com/ubi8/ubi:8.2-299 AS runtime
+FROM sysflowtelemetry/ubi:base-${UBI_TAG} AS runtime
 
 # environment variables
 ARG interval=30
@@ -106,13 +106,8 @@ LABEL "description"="Sysflow Collector monitors and collects system call and eve
 LABEL "io.k8s.display-name"="Sysflow Collector"
 LABEL "io.k8s.description"="Sysflow Collector monitors and collects system call and event information from hosts and exports them in the SysFlow format using Apache Avro object serialization"
 
-# Install Packages
-COPY ./scripts/installUBIDependency.sh /
-RUN /installUBIDependency.sh base && rm /installUBIDependency.sh
-
 # Update License
-RUN mkdir /licenses
-COPY ./LICENSE.md /licenses/
+COPY ./LICENSE.md /licenses/LICENSE.md
 
 # copy dependencies
 COPY --from=builder /usr/local/lib/ /usr/local/lib/
@@ -166,7 +161,7 @@ RUN mkdir /tmp/bats && cd /tmp/bats && \
 COPY modules/sysflow/py3 ${INSTALL_PATH}/utils
 
 RUN cd /usr/local/sysflow/utils && \
-    python3 setup.py install 
+    python3 setup.py install
 
 WORKDIR $wdir
 ENTRYPOINT ["/usr/local/bin/bats"]

--- a/Dockerfile.ubi.amd64
+++ b/Dockerfile.ubi.amd64
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:1.0-experimental
 #
 # Copyright (C) 2019 IBM Corporation.
 #
@@ -18,13 +19,29 @@
 # limitations under the License.
 
 #-----------------------
+# Usage
+#-----------------------
+#
+# 1. Modify scripts/build/secret.sh and add user/password for RHEL
+# 2. Build with Docker BuildKit:
+#
+#    DOCKER_BUILDKIT=1 docker build --no-cache \
+#                                   --secret id=rhsecret,src=scripts/build/secret.sh \
+#                                   --target mods \
+#                                   -t ubi:mods-0.0.0 \
+#                                   -f Dockerfile.ubi.amd64 .
+#
+
+#-----------------------
 # Stage: base
 #-----------------------
 FROM registry.access.redhat.com/ubi8/ubi:8.2-299 AS base
 
 # Install Packages
-COPY ./scripts/installUBIDependency.sh /
-RUN /installUBIDependency.sh base && rm /installUBIDependency.sh
+COPY ./scripts/installUBIDependency.sh /build/install.sh
+RUN --mount=type=secret,id=rhsecret,dst=/secret/rh_register.sh \
+    ( source /secret/rh_register.sh && bash /build/install.sh base ) && \
+    rm -rf /build
 
 #-----------------------
 # Stage: mods
@@ -42,14 +59,15 @@ ENV SYSDIG_HOST_ROOT=/host
 
 ENV HOME=/root
 
-RUN dnf install -y  --disableplugin=subscription-manager --disableexcludes=all --enablerepo=PowerTools git
 #  build modules
 COPY ./modules /build/modules
 COPY ./makefile.* /build/
 COPY ./docker-entry-ubi.sh /usr/local/sysflow/modules/bin/
-RUN  cd /build/modules && \
+RUN  dnf -y install git && \
+     cd /build/modules && \
      make INSTALL_PATH=${INSTALL_PATH} install && \
      mkdir /sysdigsrc && cp -a /usr/src/sysdig-* /sysdigsrc/ && \
-     make clean && rm -rf /build/modules
+     make clean && rm -rf /build/modules && \
+     dnf -y remove git && dnf -y clean all && rm -rf /var/cache/dnf
 
 ENTRYPOINT ["/usr/local/sysflow/modules/bin/docker-entry-ubi.sh"]

--- a/scripts/build/build.sh
+++ b/scripts/build/build.sh
@@ -1,3 +1,11 @@
 #!/bin/bash
 # Usage: build.sh version release target-image
-docker build --build-arg BUILD_NUMBER=$2 --build-arg VERSION=$1 --build-arg RELEASE=$2 --target runtime -t $3 .
+target_img=$3
+test_img="${target_img}-testing"
+docker build --build-arg BUILD_NUMBER=$2 \
+             --build-arg VERSION=$1 \
+             --build-arg RELEASE=$2 \
+             --target runtime \
+             -t $target_img \
+             .
+docker build --cache-from $target_img --target testing -t $test_img .

--- a/scripts/build/secret.sh
+++ b/scripts/build/secret.sh
@@ -1,0 +1,2 @@
+export REGISTER_USER='rhel-username'
+export REGISTER_PASSWORD='rhel-password'


### PR DESCRIPTION
1. Move package source from CentOS/Fedroa repositories to RHEL
2. Provide a way to insert subscription credentials during building base image
3. Install dkms from EPEL
4. Change runtime base image from vanilla UBI to SysFlow base (UBI plus
   necessary dependencies)

Note that credential for RedHat subscription is only needed while building the UBI base. SysFlow contributors are able build runnable collector on top of core develop team provided UBI base.