### PR TITLE
UBI upgrade for eBPF

### DIFF
--- a/Dockerfile.dev.amd64
+++ b/Dockerfile.dev.amd64
@@ -1,0 +1,71 @@
+# syntax = docker/dockerfile:1.0-experimental
+#
+# Copyright (C) 2019 IBM Corporation.
+#
+# Authors:
+# Frederico Araujo <frederico.araujo@ibm.com>
+# Teryl Taylor <terylt@ibm.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#-----------------------
+# Usage
+#-----------------------
+#
+# 1. Modify scripts/build/secret.sh and add user/password for RHEL
+# 2. Build with Docker BuildKit:
+#
+#    DOCKER_BUILDKIT=1 docker build --no-cache \
+#                                   --secret id=rhsecret,src=scripts/build/secret.sh \
+#                                   --target mods \
+#                                   -t ubi:mods-0.0.0 \
+#                                   -f Dockerfile.ubi.amd64 .
+#
+
+#-----------------------
+# Stage: base
+#-----------------------
+FROM registry.access.redhat.com/ubi8/ubi:8.2-299 AS base
+
+# Install Packages
+COPY ./scripts/installUBIDependencyWoSubManager.sh /build/install.sh
+RUN ( /build/install.sh base ) && rm -rf /build
+
+#-----------------------
+# Stage: mods
+#-----------------------
+FROM base AS mods
+
+# environment and args
+ARG INSTALL_PATH=/usr/local/sysflow
+
+ENV PATH="$PATH:"${INSTALL_PATH}"/modules/bin"
+
+ENV LIBRARY_PATH=/lib64
+
+ENV SYSDIG_HOST_ROOT=/host
+
+ENV HOME=/root
+
+#  build modules
+COPY ./modules /build/modules
+COPY ./makefile.* /build/
+COPY ./docker-entry-ubi.sh /usr/local/sysflow/modules/bin/
+RUN  dnf -y install git && \
+     cd /build/modules && \
+     make INSTALL_PATH=${INSTALL_PATH} install && \
+     mkdir /sysdigsrc && cp -a /usr/src/sysdig-* /sysdigsrc/ && \
+     make clean && rm -rf /build/modules && \
+     dnf -y remove git && dnf -y clean all && rm -rf /var/cache/dnf
+
+ENTRYPOINT ["/usr/local/sysflow/modules/bin/docker-entry-ubi.sh"]

--- a/scripts/installUBIDependency.sh
+++ b/scripts/installUBIDependency.sh
@@ -33,6 +33,12 @@ echo "Install Dependency under mode: ${MODE}"
 cleanup() {
     dnf -y clean all && rm -rf /var/cache/dnf
     subscription-manager unregister || true
+    dnf -y remove \
+        python3-subscription-manager-rhsm \
+        subscription-manager \
+        subscription-manager-rhsm-certificates \
+        vim-minimal \
+        || true
 }
 trap cleanup EXIT
 
@@ -41,6 +47,7 @@ trap cleanup EXIT
 #
 (
     set +x
+    which subscription-manager || dnf -y install subscription-manager
     if [ -z "$REGISTER_USER" -o -z "$REGISTER_PASSWORD" ] ; then
         echo 'Lack of RHEL credential.'
         echo 'Assume build on RHEL machines or install packages only in UBI repositories.'
@@ -83,7 +90,8 @@ if [ "${MODE}" == "base" ] ; then
         sparsehash-devel \
         snappy-devel \
         glog-devel \
-        llvm-toolset
+        clang \
+        llvm
 
     # Install dkms and jsoncpp from EPEL.
     # ref: https://access.redhat.com/solutions/1132653
@@ -94,7 +102,7 @@ if [ "${MODE}" == "base" ] ; then
 elif [ "${MODE}" == "test-extra" ] ; then
     # additional packages for testing
 
-    dnf -y install python3 python3-devel python3-wheel
+    dnf -y --noplugins install python3 python3-devel python3-wheel
     mkdir -p /usr/local/lib/python3.6/site-packages
     ln -s /usr/bin/easy_install-3 /usr/bin/easy_install
     ln -s /usr/bin/python3 /usr/bin/python

--- a/scripts/installUBIDependency.sh
+++ b/scripts/installUBIDependency.sh
@@ -82,7 +82,8 @@ if [ "${MODE}" == "base" ] ; then
         elfutils-libelf-devel \
         sparsehash-devel \
         snappy-devel \
-        glog-devel
+        glog-devel \
+        llvm-toolset
 
     # Install dkms and jsoncpp from EPEL.
     # ref: https://access.redhat.com/solutions/1132653

--- a/scripts/installUBIDependencyWoSubManager.sh
+++ b/scripts/installUBIDependencyWoSubManager.sh
@@ -27,11 +27,25 @@ MODE=${1:-base}
 
 echo "Install Dependency under mode: ${MODE}"
 
+#
+# Clean up function
+#
+cleanup() {
+    dnf -y clean all && rm -rf /var/cache/dnf
+}
+trap cleanup EXIT
+
 if [ "${MODE}" == "base" ] ; then
-     # packages for base image
-     dnf install -y --disableplugin=subscription-manager http://mirror.centos.org/centos/8/BaseOS/x86_64/os/Packages/centos-gpg-keys-8.2-2.2004.0.1.el8.noarch.rpm http://mirror.centos.org/centos/8/BaseOS/x86_64/os/Packages/centos-repos-8.2-2.2004.0.1.el8.x86_64.rpm
-     dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-     dnf -y install --enablerepo=PowerTools --disablerepo=ubi-8-codeready-builder  --disablerepo=ubi-8-appstream --disablerepo=ubi-8-baseos --disableplugin=subscription-manager \
+    # packages for base image
+    dnf -y install --disableplugin=subscription-manager \
+        http://mirror.centos.org/centos/8/BaseOS/x86_64/os/Packages/centos-gpg-keys-8.2-2.2004.0.1.el8.noarch.rpm http://mirror.centos.org/centos/8/BaseOS/x86_64/os/Packages/centos-repos-8.2-2.2004.0.1.el8.x86_64.rpm
+    dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+    dnf -y install \
+        --disableplugin=subscription-manager \
+        --disablerepo=ubi-8-appstream \
+        --disablerepo=ubi-8-baseos \
+        --disablerepo=ubi-8-codeready-builder \
+        --enablerepo=PowerTools \
         gcc \
         gcc-c++ \
         make \
@@ -52,31 +66,37 @@ if [ "${MODE}" == "base" ] ; then
         apr-devel \
         apr-util-devel \
         openssl-devel \
-    	flex \
+        flex \
         bison \
-	    libstdc++-static \
-	    boost-devel \
+        libstdc++-static \
+        boost-devel \
         elfutils-libelf-devel \
-	    sparsehash-devel \
-	    snappy-devel \
-	    jsoncpp-devel \
-	    glog-devel \
+        sparsehash-devel \
+        snappy-devel \
+        jsoncpp-devel \
+        glog-devel \
         llvm-toolset
 
-     dnf install -y --disableplugin=subscription-manager --disableexcludes=all --enablerepo=epel --disablerepo=ubi-8-codeready-builder  --disablerepo=ubi-8-appstream --disablerepo=ubi-8-baseos  dkms
-     dnf -y clean all && rm -rf /var/cache/dnf
+    dnf -y install \
+        --disableexcludes=all \
+        --disableplugin=subscription-manager \
+        --disablerepo=ubi-8-appstream \
+        --disablerepo=ubi-8-baseos \
+        --disablerepo=ubi-8-codeready-builder \
+        --enablerepo=epel \
+        dkms
 
- elif [ "${MODE}" == "test-extra" ] ; then
+elif [ "${MODE}" == "test-extra" ] ; then
     # additional packages for testing
-    dnf install -y --disableplugin=subscription-manager \
-	    python3 \
+
+    dnf -y install --disableplugin=subscription-manager \
+        python3 \
         python3-devel \
-        python3-wheel && \
-    mkdir -p /usr/local/lib/python3.6/site-packages && \
-    ln -s /usr/bin/easy_install-3 /usr/bin/easy_install && \
-    ln -s /usr/bin/python3 /usr/bin/python && \
-    ln -s /usr/bin/pip3 /usr/bin/pip && \
-    dnf -y clean all && rm -rf /var/cache/dnf
+        python3-wheel
+    mkdir -p /usr/local/lib/python3.6/site-packages
+    ln -s /usr/bin/easy_install-3 /usr/bin/easy_install
+    ln -s /usr/bin/python3 /usr/bin/python
+    ln -s /usr/bin/pip3 /usr/bin/pip
 
 else
     echo "Unsupported mode: ${MODE}"

--- a/src/Makefile
+++ b/src/Makefile
@@ -58,7 +58,7 @@ LDFLAGS = $(LIBS) -L/usr/local/lib/ -L$(LIBPREFIX)/ -L$(SDLOCALLIBPREFIX)/ -L$(A
 CFLAGS = -std=c++11 -Wall -ggdb -I.. -I$(SFLOCALINCPREFIX)/ -I$(FSLOCALINCPREFIX)/ \
 		-DHAS_CAPTURE -DPLATFORM_NAME=\"Linux\" -DK8S_DISABLE_THREAD \
 	 	-I$(SDLOCALINCPREFIX)/ -I$(SDLOCALINCPREFIX)/curl/ -I$(SDLOCALINCPREFIX)/json/ -I$(SDLOCALINCPREFIX)/openssl/ -I$(SDLOCALINCPREFIX)/driver/ \
-		-I$(SDLOCALINCPREFIX)/userspace/libsinsp/ -I$(SDLOCALINCPREFIX)/userspace/libscap/ -I$(AVRLOCALINCPREFIX)/ -I/usr/local/include/ -I/usr/include/jsoncpp/
+		-I$(SDLOCALINCPREFIX)/userspace/libsinsp/ -I$(SDLOCALINCPREFIX)/userspace/libscap/ -I$(AVRLOCALINCPREFIX)/ -I/usr/local/include/ -I/usr/include/
 
 .PHONY: all
 all: version $(TARGET)


### PR DESCRIPTION
1. Upgrade Sysdig to 0.27.0
2. Add runtime dependency to base/mods image for eBPF, reduce image size
3. Fix including problem while compiling collector
4. Add package installer for RHEL-free development.