### PR TITLE
Rename environment variable that enables driver logging

### DIFF
--- a/src/sysflowcontext.cpp
+++ b/src/sysflowcontext.cpp
@@ -46,7 +46,7 @@ SysFlowContext::SysFlowContext(bool fCont, int fDur, string oFile,
   if (m_criTO > 0) {
     m_inspector->set_cri_timeout(m_criTO);
   }
-  const char *envP = std::getenv(SYSDIG_LOG);
+  const char *envP = std::getenv(DRIVER_LOG);
   if (envP != nullptr && strcmp(envP, "1") == 0) {
     m_inspector->set_log_stderr();
     m_inspector->set_min_log_severity(sinsp_logger::severity::SEV_DEBUG);

--- a/src/sysflowcontext.h
+++ b/src/sysflowcontext.h
@@ -31,7 +31,7 @@
 #include <sinsp.h>
 #include <unistd.h>
 
-#define SYSDIG_LOG "SYSDIG_LOG"
+#define DRIVER_LOG "DRIVER_LOG"
 #define NODE_IP "NODE_IP"
 #define ENABLE_DROP_MODE "ENABLE_DROP_MODE"
 #define FILE_READ_MODE "FILE_READ_MODE"


### PR DESCRIPTION
**Description** 
This PR renames the environment variable that enables driver debug logging. 

**Usage**
To enable driver logging, set `DRIVER_LOG=1` in the collector environment. 

Signed-off-by: Frederico Araujo <frederico.araujo@ibm.com>