### PR TITLE
Update prepackage.sh

### DIFF
--- a/scripts/cpack/prepackage.sh
+++ b/scripts/cpack/prepackage.sh
@@ -8,7 +8,7 @@ DRIVER_SRC_PATH=$(find /usr/src -name "falco-*")
 cd $DIR && rm -rf $BUILD_DIR && mkdir -p $BUILD_DIR
 cp -a $DIR/../../bin $DIR/$BUILD_DIR/bin
 mkdir -p $DIR/$BUILD_DIR/lib && cp -a /usr/lib/sysflow $DIR/$BUILD_DIR/lib
-mkdir -p $DIR/$BUILD_DIR/driver && cp -a /usr/bin/falco-driver-loader $DIR/$BUILD_DIR/driver/.
+mkdir -p $DIR/$BUILD_DIR/driver && cp -a /usr/bin/falcoctl $DIR/$BUILD_DIR/driver/.
 mkdir -p $DIR/$BUILD_DIR/src && cp -a $DRIVER_SRC_PATH $DIR/$BUILD_DIR/src/$(basename $DRIVER_SRC_PATH)
 mkdir -p $DIR/$BUILD_DIR/modules/src/dkms && cp -a $DIR/../../modules/src/dkms/*  $DIR/$BUILD_DIR/modules/src/dkms
 mkdir -p $DIR/$BUILD_DIR/modules/bin && cp -a $(which make)  $DIR/$BUILD_DIR/modules/bin/make


### PR DESCRIPTION
Hello. 
Looks like falco-driver-loader should be replaced by falcoctl to successfully build packages from docker image 0.7.0-rc1.